### PR TITLE
Make program quit gracefully on timeout

### DIFF
--- a/main.py
+++ b/main.py
@@ -183,4 +183,4 @@ if __name__ == '__main__':
             f.write('\n')
         print('Done! :D')
     except requests.exceptions.RequestException:
-        print("There was problem connecting to the APIs, check your internet connection and ttry again")
+        print("There was problem connecting to the APIs, check your internet connection and try again")

--- a/main.py
+++ b/main.py
@@ -169,11 +169,11 @@ if __name__ == '__main__':
             gbif_data = getGBIFData(name)
             # Get GBIF Data from similar name
             if gbif_data == 'Not Found' and AUTO_SEARCH_SIMILAR_SPECIES and description != 'Not Found':
-              similar_name = re.search(name.split()[0] + ' .+', description)
-              gbif_data = getGBIFData(similar_name)
+                similar_name = re.search(name.split()[0] + ' .+', description)
+                gbif_data = getGBIFData(similar_name)
             # Get GBIF Data from first word
             if gbif_data == 'Not Found' and name.split()[0] != name:
-              gbif_data = getGBIFData(name.split()[0])
+                gbif_data = getGBIFData(name.split()[0])
             f.write('### ' + name)
             f.write('\n')
             f.write(description or 'Not Found')

--- a/main.py
+++ b/main.py
@@ -155,29 +155,32 @@ if __name__ == '__main__':
     # Fetch and Write Output
     f = open(outputfile, 'a')
     print('Starting, it may take a while, please wait...')
-    for name in scientific_names:
-        # Non-scientific search tag enabled
-        if name[-2:] == '-n':
-            name = getScientificName(name[:-2])
+    try:
+        for name in scientific_names:
+            # Non-scientific search tag enabled
+            if name[-2:] == '-n':
+                name = getScientificName(name[:-2])
 
-        print('Looking up:', name)
+            print('Looking up:', name)
 
-        # Get Description
-        description = getDescription(name)
-        # Get GBIF Data from name
-        gbif_data = getGBIFData(name)
-        # Get GBIF Data from similar name
-        if gbif_data == 'Not Found' and AUTO_SEARCH_SIMILAR_SPECIES and description != 'Not Found':
-            similar_name = re.search(name.split()[0] + ' .+', description)
-            gbif_data = getGBIFData(similar_name)
-        # Get GBIF Data from first word
-        if gbif_data == 'Not Found' and name.split()[0] != name:
-            gbif_data = getGBIFData(name.split()[0])
-        f.write('### ' + name)
-        f.write('\n')
-        f.write(description or 'Not Found')
-        f.write('\n')
-        f.write(gbif_data or 'Not Found')
-        f.write('\n')
-        f.write('\n')
-    print('Done! :D')
+            # Get Description
+            description = getDescription(name)
+            # Get GBIF Data from name
+            gbif_data = getGBIFData(name)
+            # Get GBIF Data from similar name
+            if gbif_data == 'Not Found' and AUTO_SEARCH_SIMILAR_SPECIES and description != 'Not Found':
+              similar_name = re.search(name.split()[0] + ' .+', description)
+              gbif_data = getGBIFData(similar_name)
+            # Get GBIF Data from first word
+            if gbif_data == 'Not Found' and name.split()[0] != name:
+              gbif_data = getGBIFData(name.split()[0])
+            f.write('### ' + name)
+            f.write('\n')
+            f.write(description or 'Not Found')
+            f.write('\n')
+            f.write(gbif_data or 'Not Found')
+            f.write('\n')
+            f.write('\n')
+        print('Done! :D')
+    except requests.exceptions.RequestException:
+        print("There was problem connecting to the APIs, check your internet connection and ttry again")

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,8 @@ from unittest import TestCase, main as test_main
 from unittest.mock import patch
 import main
 from datetime import date
+from requests import Timeout
+from requests.exceptions import RequestException
 
 
 class Tests(TestCase):
@@ -11,7 +13,7 @@ class Tests(TestCase):
         testargs = ["main", "-i", "my_test_input.txt",
                     "-o", "my_test_output.txt"]
         with patch.object(sys, 'argv', testargs):
-            inputfile, outputfile = main.readArgs()
+            inputfile, outputfile, _ = main.readArgs()
             self.assertEqual(inputfile, "my_test_input.txt")
             self.assertEqual(outputfile, "my_test_output.txt")
 
@@ -22,9 +24,14 @@ class Tests(TestCase):
                 mock_datetime.now.return_value = date(2021, 10, 31)
                 mock_datetime.side_effect = lambda *args, **kw: date(
                     *args, **kw)
-                inputfile, outputfile = main.readArgs()
+                inputfile, outputfile, _ = main.readArgs()
                 self.assertEqual(inputfile, "input.txt")
                 self.assertEqual(outputfile, "result.2021-10-31.00:00:00.txt")
+
+    @patch('main.requests.get', side_effect=Timeout())
+    def test_api_timeout(self, mocked_get):
+        with self.assertRaises(RequestException):
+            main.getDescription("name")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch makes the script end with a message when the API does not respond due to a timeout or due to any generic connection error that happens during the GET.

I also included a small test that checks if the expected exception (the generic `RequestException` from the `requests` module) is being raised by the getResponse function.

It would be ideal to do a bigger test with the whole script instead of just checking one of the API functions but that would require additional refactoring (like putting the whole fetching portion of the script into a testable function instead of leaving it under the` if __main__` check).

This can be manually tested by simply disabling your network and running the script. Before, the program would be stuck for a couple of seconds and terminate with an Exception. After this patch, instead of an exception it will print out a message telling the user that it couldn't connect to the API to fetch the information.